### PR TITLE
Feat: add calendar state

### DIFF
--- a/components/states/CalendarState.jsx
+++ b/components/states/CalendarState.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { useActor } from "@xstate/react";
+import Calendar from "react-calendar";
+
+// https://gist.github.com/wojtekmaj/a36712e5f8ea6e035ef8d845ab246cd5
+// import styles from "./CalendarState.module.css";
+// https://projects.wojtekmaj.pl/react-calendar/
+
+// Style defined at:
+// styles/calendar.css
+
+import { STATE_ACTIONS } from "../../utils/state-machine";
+import StatePage from "./shared/StatePage";
+import StateTitle from "./shared/StateTitle";
+import { MyContext } from "../ReservationController";
+
+function disabledDates({ activeStartDate, date, view }) {
+  const todaysDate = new Date();
+  return date < todaysDate;
+}
+
+const CalendarState = () => {
+  const machine = React.useContext(MyContext);
+
+  const [date, setDate] = React.useState(new Date());
+
+  const [state, send] = useActor(machine);
+
+  return (
+    <StatePage>
+      <StateTitle title="Select date" />
+      <div className="flex flex-col">
+        <Calendar
+          onChange={(value) => {
+            send({
+              type: STATE_ACTIONS.COMPLETE,
+              value,
+            });
+          }}
+          value={date}
+          tileDisabled={disabledDates}
+          view="month"
+        />
+      </div>
+    </StatePage>
+  );
+};
+
+export default CalendarState;

--- a/components/states/StateController.jsx
+++ b/components/states/StateController.jsx
@@ -4,6 +4,7 @@ import { useActor } from "@xstate/react";
 import ReservationTypeState from "./ReservationTypeState";
 import CertificationDiveState from "./CertificationDiveState";
 import CompleteState from "./CompleteState";
+import CalendarState from "./CalendarState";
 import { MyContext } from "../ReservationController";
 
 const StateController = () => {
@@ -15,6 +16,8 @@ const StateController = () => {
       return <ReservationTypeState />;
     case state.matches("certificationDive"):
       return <CertificationDiveState />;
+    case state.matches("calendar"):
+      return <CalendarState />;
     case state.matches("complete"):
       return <CompleteState />;
     default:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "latest": "^0.2.0",
     "next": "12.1.0",
     "react": "17.0.2",
+    "react-calendar": "^3.7.0",
     "react-dom": "17.0.2",
     "xstate": "^4.32.1"
   },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,5 @@
 import "../styles/globals.css";
+import "../styles/calendar.css";
 
 function MyApp({ Component, pageProps }) {
   return <Component {...pageProps} />;

--- a/styles/calendar.css
+++ b/styles/calendar.css
@@ -1,0 +1,121 @@
+.react-calendar {
+  width: 350px;
+  max-width: 100%;
+  background: white;
+  border: 0;
+  border-radius: 4px;
+  font-weight: 500;
+  line-height: 1.125em;
+  filter: drop-shadow(0 25px 25px rgb(0 0 0 / 0.15));
+}
+.react-calendar--doubleView {
+  width: 700px;
+}
+.react-calendar--doubleView .react-calendar__viewContainer {
+  display: flex;
+  margin: -0.5em;
+}
+.react-calendar--doubleView .react-calendar__viewContainer > * {
+  width: 50%;
+  margin: 0.5em;
+}
+.react-calendar,
+.react-calendar *,
+.react-calendar *:before,
+.react-calendar *:after {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.react-calendar button {
+  margin: 0;
+  border: 0;
+  outline: none;
+}
+.react-calendar button:enabled:hover {
+  cursor: pointer;
+}
+.react-calendar__navigation {
+  display: flex;
+  height: 44px;
+  margin-bottom: 1em;
+  /* height: 44px; */
+  /* margin-bottom: 10px; */
+}
+.react-calendar__navigation button {
+  min-width: 44px;
+  background: none;
+}
+.react-calendar__navigation button:disabled {
+  background-color: #f0f0f0;
+}
+.react-calendar__navigation button:enabled:hover,
+.react-calendar__navigation button:enabled:focus {
+  background-color: #e6e6e6;
+}
+.react-calendar__month-view__weekdays {
+  text-align: center;
+  text-transform: uppercase;
+  font-weight: bold;
+  font-size: 0.75em;
+}
+.react-calendar__month-view__weekdays__weekday {
+  padding: 0.5em;
+}
+.react-calendar__month-view__weekNumbers .react-calendar__tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75em;
+  font-weight: bold;
+}
+.react-calendar__month-view__days__day--weekend {
+  color: #d10000;
+}
+.react-calendar__month-view__days__day--neighboringMonth {
+  color: #757575;
+}
+.react-calendar__year-view .react-calendar__tile,
+.react-calendar__decade-view .react-calendar__tile,
+.react-calendar__century-view .react-calendar__tile {
+  padding: 2em 0.5em;
+}
+.react-calendar__tile {
+  max-width: 100%;
+  padding: 10px 6.6667px;
+  background: none;
+  text-align: center;
+  line-height: 16px;
+}
+.react-calendar__tile:disabled {
+  background-color: #f0f0f0;
+}
+.react-calendar__tile:enabled:hover,
+.react-calendar__tile:enabled:focus {
+  background-color: #e6e6e6;
+}
+.react-calendar__tile--now {
+  background: #ffff76;
+}
+.react-calendar__tile--now:enabled:hover,
+.react-calendar__tile--now:enabled:focus {
+  background: #ffffa9;
+}
+.react-calendar__tile--hasActive {
+  background: #76baff;
+}
+.react-calendar__tile--hasActive:enabled:hover,
+.react-calendar__tile--hasActive:enabled:focus {
+  background: #a9d4ff;
+}
+.react-calendar__tile--active {
+  background: #006edc;
+  color: white;
+}
+.react-calendar__tile--active:enabled:hover,
+.react-calendar__tile--active:enabled:focus {
+  background: #1087ff;
+}
+.react-calendar--selectRange .react-calendar__tile--hover {
+  background-color: #e6e6e6;
+}

--- a/utils/state-machine.js
+++ b/utils/state-machine.js
@@ -8,12 +8,16 @@ const setReservationType = assign({
 const setCertificationType = assign({
   certificationType: (context, event) => event.value,
 });
+const setDate = assign({
+  date: (context, event) => event.value,
+});
 
 export const STATE_ACTIONS = {
   NEXT: "next",
   PREV: "prev",
   CERTIFICATION_DIVE: "CERTIFICATION_DIVE",
   RECREATIONAL_DIVE: "RECREATIONAL_DIVE",
+  COMPLETE: "complete",
 };
 
 // Stateless machine definition
@@ -24,6 +28,7 @@ export const reservationMachine = createMachine(
     context: {
       reservationType: null,
       certificationType: null,
+      date: null,
     },
     states: {
       reservation: {
@@ -33,7 +38,7 @@ export const reservationMachine = createMachine(
             actions: "setReservationType",
           },
           [STATE_ACTIONS.RECREATIONAL_DIVE]: {
-            target: "complete",
+            target: "calendar",
             actions: "setReservationType",
           },
         },
@@ -41,8 +46,16 @@ export const reservationMachine = createMachine(
       certificationDive: {
         on: {
           [STATE_ACTIONS.NEXT]: {
-            target: "complete",
+            target: "calendar",
             actions: "setCertificationType",
+          },
+        },
+      },
+      calendar: {
+        on: {
+          [STATE_ACTIONS.COMPLETE]: {
+            target: "complete",
+            actions: "setDate",
           },
         },
       },
@@ -53,6 +66,7 @@ export const reservationMachine = createMachine(
     actions: {
       setReservationType,
       setCertificationType,
+      setDate,
     },
   }
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -226,6 +226,11 @@
     "@typescript-eslint/types" "5.12.1"
     eslint-visitor-keys "^3.0.0"
 
+"@wojtekmaj/date-utils@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@wojtekmaj/date-utils/-/date-utils-1.0.3.tgz#2dcfd92881425c5923e429c2aec86fb3609032a1"
+  integrity sha512-1VPkkTBk07gMR1fjpBtse4G+oJqpmE+0gUFB0dg3VIL7qJmUVaBoD/vlzMm/jNeOPfvlmerl1lpnsZyBUFIRuw==
+
 "@xstate/react@^3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@xstate/react/-/react-3.0.0.tgz"
@@ -290,11 +295,6 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
-
-ansi-regex@*:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -1545,6 +1545,13 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
+get-user-locale@^1.2.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/get-user-locale/-/get-user-locale-1.5.0.tgz#5f5881197185a6c9f4fe35019a3c68430738ef7c"
+  integrity sha512-+KdoVdvyIVrv7HIcAaxKWyS3ulDgcblBt0SvjMwxbH3xi10JCEIt1LcRsN1RW+O6kKSFGTFUAtXmromAf3YkOw==
+  dependencies:
+    lodash.memoize "^4.1.1"
+
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
@@ -1801,7 +1808,7 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -2159,6 +2166,11 @@ lodash.isplainobject@^4.0.6:
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
 
+lodash.memoize@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
@@ -2210,6 +2222,11 @@ mdn-data@2.0.14:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
   integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
+
+merge-class-names@^1.1.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/merge-class-names/-/merge-class-names-1.4.2.tgz#78d6d95ab259e7e647252a7988fd25a27d5a8835"
+  integrity sha512-bOl98VzwCGi25Gcn3xKxnR5p/WrhWFQB59MS/aGENcmUc6iSm96yrFDF0XSNurX9qN4LbJm0R9kfvsQ17i8zCw==
 
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
@@ -2862,7 +2879,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.8.1:
+prop-types@^15.6.0, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -2920,6 +2937,16 @@ quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
+react-calendar@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/react-calendar/-/react-calendar-3.7.0.tgz#951d56e91afb33b1c1e019cb790349fbffcc6894"
+  integrity sha512-zkK95zWLWLC6w3O7p3SHx/FJXEyyD2UMd4jr3CrKD+G73N+G5vEwrXxYQCNivIPoFNBjqoyYYGlkHA+TBDPLCw==
+  dependencies:
+    "@wojtekmaj/date-utils" "^1.0.2"
+    get-user-locale "^1.2.0"
+    merge-class-names "^1.1.1"
+    prop-types "^15.6.0"
 
 react-dom@17.0.2:
   version "17.0.2"


### PR DESCRIPTION
Add calendar state.

Note: 
This state is incomplete. Ideally, on this step we also add which hours the dive will take place. That can happen after you click the date, which will add after. This is something we will need to discuss with Dive shops to see how we do it, or also have the option for the Dive shop to define.

In the mean time, I will just allow users to click on the date.

Potential improvements:
1. Don't allow user to go before the current date (currently is allowed)
2. Have a button that returns view to Today's date (currently you need to figure out how to do that.
3. Allow user to look at "year" view (I disabled it because I need to figure out the disabled better)

Using this library: https://github.com/wojtekmaj/react-calendar



UI:
<img width="421" alt="image" src="https://user-images.githubusercontent.com/11667804/182184183-439cf3f0-1105-4a68-8504-689a6b7689fe.png">
