### PR TITLE
Feat: add admin mobile framework

### DIFF
--- a/components/admin_real/Dashboard.jsx
+++ b/components/admin_real/Dashboard.jsx
@@ -1,31 +1,17 @@
 import React from "react";
-import Sidebar from "./Sidebar";
 
-import Body from "./Body";
-import Header from "./Header";
-
-import styles from "./calendar.module.css";
-
-export const VIEWS = {
-  RESERVATIONS: "r",
-  CALENDAR: "c",
-};
+import MobileDashboard from "./mobil/MobileDashboard";
+import DesktopDashboard from "./DesktopDashboard";
 
 export default function Dashboard() {
-  const [view, setView] = React.useState(VIEWS.RESERVATIONS);
   return (
-    <div className="w-screen h-full bg-gray-50">
-      <div className={styles.container}>
-        <div className={styles.header}>
-          <Header />
-        </div>
-        <div className={styles.sidebar}>
-          <Sidebar view={view} views={VIEWS} setView={setView} />
-        </div>
-        <div className={styles.main}>
-          <Body view={view} />
-        </div>
+    <>
+      <div className="sm:hidden">
+        <MobileDashboard />
       </div>
-    </div>
+      <div className="hidden sm:inline">
+        <DesktopDashboard />
+      </div>
+    </>
   );
 }

--- a/components/admin_real/DesktopDashboard.jsx
+++ b/components/admin_real/DesktopDashboard.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import Sidebar from "./Sidebar";
+
+import Body from "./Body";
+import Header from "./Header";
+
+import styles from "./calendar.module.css";
+
+export const VIEWS = {
+  RESERVATIONS: "r",
+  CALENDAR: "c",
+};
+
+export default function Dashboard() {
+  const [view, setView] = React.useState(VIEWS.RESERVATIONS);
+  return (
+    <div className="w-screen h-full bg-gray-50">
+      <div className={styles.container}>
+        <div className={styles.header}>
+          <Header />
+        </div>
+        <div className={styles.sidebar}>
+          <Sidebar view={view} views={VIEWS} setView={setView} />
+        </div>
+        <div className={styles.main}>
+          <Body view={view} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/admin_real/Header.jsx
+++ b/components/admin_real/Header.jsx
@@ -1,9 +1,10 @@
-export default function Header() {
+export default function Header(props) {
   return (
-    <div className="h-full bg-white border border-slate-300">
-      <div className="py-2 ml-3">
-        <h1 className="text-xl font-normal text-sky-700">DiverList</h1>
+    <div className="h-full py-2 justify-between	flex flex-row bg-white border border-slate-300">
+      <div className="ml-3">
+        <span className="text-xl font-normal text-sky-700">DiverList</span>
       </div>
+      {props.rightChildren ? props.rightChildren : null}
     </div>
   );
 }

--- a/components/admin_real/dashboard.module.css
+++ b/components/admin_real/dashboard.module.css
@@ -1,0 +1,8 @@
+@media screen and (min-width: 900px) {
+  .mobile {
+    display: none;
+  }
+  .desktop {
+    display: none;
+  }
+}

--- a/components/admin_real/mobil/Body.jsx
+++ b/components/admin_real/mobil/Body.jsx
@@ -1,8 +1,10 @@
 import React from "react";
-import ReservationTable from "./ReservationTable";
+import ReservationTable from "../ReservationTable";
 
-import { VIEWS } from "./DesktopDashboard";
-import Calendar from "./Calendar";
+export const VIEWS = {
+  RESERVATIONS: "r",
+  CALENDAR: "c",
+};
 
 const BodyFrame = (props) => {
   return <div className="mt-10 mr-5">{props.children}</div>;
@@ -13,14 +15,14 @@ export default function Body({ view }) {
     case VIEWS.CALENDAR:
       return (
         <BodyFrame>
-          <Calendar />
+          <div>Calendar</div>
         </BodyFrame>
       );
     case VIEWS.RESERVATIONS:
     default:
       return (
         <BodyFrame>
-          <ReservationTable />
+          <div>Reservation</div>
         </BodyFrame>
       );
   }

--- a/components/admin_real/mobil/Calendar.jsx
+++ b/components/admin_real/mobil/Calendar.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import Header from "../Header";
+import AutoAwesomeMosaicIcon from "@mui/icons-material/AutoAwesomeMosaic";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
+
+export default function MobileDashboard() {
+  return (
+    <div className="w-screen h-full bg-gray-50">
+      <Header
+        rightChildren={
+          <div className="flex flex-row align-items-center space-x-2 mr-3">
+            <AutoAwesomeMosaicIcon />
+            <CalendarMonthIcon />
+          </div>
+        }
+      />
+    </div>
+  );
+}

--- a/components/admin_real/mobil/MobileDashboard.jsx
+++ b/components/admin_real/mobil/MobileDashboard.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import AutoAwesomeMosaicIcon from "@mui/icons-material/AutoAwesomeMosaic";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
+import IconButton from "@mui/material/IconButton";
+
+import Body, { VIEWS } from "./Body";
+import Header from "../Header";
+
+export default function MobileDashboard() {
+  const [view, setView] = React.useState(VIEWS.RESERVATIONS);
+
+  return (
+    <div className="w-screen h-full bg-gray-50">
+      <Header
+        rightChildren={
+          <div className="flex flex-row align-items-center space-x-2 mr-3">
+            <IconButton
+              aria-label="reservations"
+              size="large"
+              color={view === VIEWS.RESERVATIONS ? "primary" : "default"}
+              onClick={() => setView("r")}
+            >
+              <AutoAwesomeMosaicIcon />
+            </IconButton>
+            <IconButton
+              aria-label="calendar"
+              size="large"
+              color={view === VIEWS.CALENDAR ? "primary" : "default"}
+              onClick={() => setView("c")}
+            >
+              <CalendarMonthIcon />
+            </IconButton>
+          </div>
+        }
+      />
+      <Body view={view} />
+    </div>
+  );
+}

--- a/components/admin_real/mobil/ReservationTable.jsx
+++ b/components/admin_real/mobil/ReservationTable.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import Header from "../Header";
+import AutoAwesomeMosaicIcon from "@mui/icons-material/AutoAwesomeMosaic";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
+
+export default function MobileDashboard() {
+  return (
+    <div className="w-screen h-full bg-gray-50">
+      <Header
+        rightChildren={
+          <div className="flex flex-row align-items-center space-x-2 mr-3">
+            <AutoAwesomeMosaicIcon />
+            <CalendarMonthIcon />
+          </div>
+        }
+      />
+    </div>
+  );
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6"
+    "target": "es6",
+    "baseUrl": "src"
   },
   "exclude": ["node_modules"],
   "include": ["src/**/*"]


### PR DESCRIPTION
I am going to make the admin mobile experience completely different than the desktop (create everything from scratch, new components, etc)

Why?
I think this will give us way more power, and flexibility to built the best mobile experience. I will reuse components when possible

UI:
<img width="508" alt="image" src="https://user-images.githubusercontent.com/11667804/193956637-4eb4d8e7-bbb1-4c1d-96a2-8b0a11b9d7a9.png">
