### PR TITLE
styling nits for reservation flow

### DIFF
--- a/components/states/CertificationDiveState.jsx
+++ b/components/states/CertificationDiveState.jsx
@@ -29,7 +29,7 @@ const CertificationDiveState = () => {
               height={150}
             />
           }
-          iconClassName="ml-8"
+          iconClassName="md:ml-8 ml-5"
           text={statesText.certificationDiveState.openWater[context.language]}
           onClick={() =>
             send({
@@ -49,6 +49,7 @@ const CertificationDiveState = () => {
               layout="fixed"
             />
           }
+          iconClassName="scale-75 md:scale-100"
           text="Advanced Open Water"
           onClick={() =>
             send({
@@ -67,6 +68,7 @@ const CertificationDiveState = () => {
               height={150}
             />
           }
+          iconClassName="scale-90 md:scale-100"
           text="Rescue Diver"
           onClick={() =>
             send({


### PR DESCRIPTION
before:
<img width="604" alt="image" src="https://user-images.githubusercontent.com/29632564/196052015-c9c4e901-c42e-43fd-97b9-6eee36ac60bb.png">



after:
<img width="632" alt="image" src="https://user-images.githubusercontent.com/29632564/196051986-0ae1e3f2-9097-4110-8a22-b364a34f3c08.png">
