### PR TITLE
Feat: change equipment state values to be integers instead of text

### DIFF
--- a/components/states/EquipmentState.jsx
+++ b/components/states/EquipmentState.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useActor } from "@xstate/react";
 import { Button } from "@mui/material";
+import { startCase } from "lodash";
 
 import { STATE_ACTIONS } from "../../utils/state-machine";
 import { MyContext } from "../ReservationController";
@@ -9,17 +10,19 @@ import StateTitle from "./shared/StateTitle";
 import StateCards from "./shared/StateCards";
 import EquipmentCard from "./shared/EquipmentCard";
 import { statesText } from "../../utils/app-text";
+import { EQUIPMENT } from "../../utils/supabase";
+import { dictionary } from "../../utils/dictionary";
 
 const EquipmentState = () => {
   const context = React.useContext(MyContext);
   const [, send] = useActor(context.service);
 
-  const [finSize, setFinSize] = React.useState("");
-  const [bcdSize, setBcdSize] = React.useState("");
-  const [wetsuitSize, setWetsuitSize] = React.useState("");
-  const [regulatorChoice, setRegulatorChoice] = React.useState("");
-  const [maskChoice, setMaskChoice] = React.useState("");
-  const [tankSize, setTankSize] = React.useState("");
+  const [finSize, setFinSize] = React.useState(null);
+  const [bcdSize, setBcdSize] = React.useState(null);
+  const [wetsuitSize, setWetsuitSize] = React.useState(null);
+  const [regulatorChoice, setRegulatorChoice] = React.useState(null);
+  const [maskChoice, setMaskChoice] = React.useState(null);
+  const [tankSize, setTankSize] = React.useState(null);
 
   return (
     <StatePage>
@@ -28,49 +31,54 @@ const EquipmentState = () => {
         <StateCards>
           <EquipmentCard
             icon="/icons/fins.svg"
-            options={statesText.equipmentState.finOptions}
+            options={EQUIPMENT.FINS}
             choice={finSize}
             setChoice={setFinSize}
-            text={statesText.equipmentState.fins[context.language]}
+            text={startCase(dictionary.fins[context.language])}
+            selectLabel={startCase(dictionary.size[context.language])}
           />
           <EquipmentCard
             icon="/icons/diving-mask.svg"
-            options={statesText.equipmentState.maskOptions[context.language]}
+            options={EQUIPMENT.MASK}
             choice={maskChoice}
             setChoice={setMaskChoice}
-            text={statesText.equipmentState.mask[context.language]}
+            text={startCase(dictionary.mask[context.language])}
+            selectLabel={startCase(dictionary.choice[context.language])}
           />
-          <EquipmentCard
-            icon="/icons/diving-suit.svg"
-            options={statesText.equipmentState.bcdOptions[context.language]}
-            choice={bcdSize}
-            setChoice={setBcdSize}
-            text="BCD"
-          />
+
           <EquipmentCard
             icon="/icons/wetsuit.svg"
-            options={statesText.equipmentState.wetsuitOptions[context.language]}
+            options={EQUIPMENT.WETSUIT}
             choice={wetsuitSize}
             setChoice={setWetsuitSize}
             text={statesText.equipmentState.wetsuit[context.language]}
+            selectLabel={startCase(dictionary.size[context.language])}
           />
         </StateCards>
         <StateCards>
           <EquipmentCard
+            icon="/icons/diving-suit.svg"
+            options={EQUIPMENT.BCD}
+            choice={bcdSize}
+            setChoice={setBcdSize}
+            text="BCD"
+            selectLabel={startCase(dictionary.size[context.language])}
+          />
+          <EquipmentCard
             icon="/icons/regulator.svg"
-            options={
-              statesText.equipmentState.regulatorOptions[context.language]
-            }
+            options={EQUIPMENT.REGULATOR}
             choice={regulatorChoice}
             setChoice={setRegulatorChoice}
             text={statesText.equipmentState.regulator[context.language]}
+            selectLabel={startCase(dictionary.choice[context.language])}
           />
           <EquipmentCard
             icon="/icons/oxygen-tank.svg"
-            options={statesText.equipmentState.tankOptions[context.language]}
+            options={EQUIPMENT.TANK}
             choice={tankSize}
             setChoice={setTankSize}
             text={statesText.equipmentState.tank[context.language]}
+            selectLabel={startCase(dictionary.size[context.language])}
           />
         </StateCards>
         <div className="mt-10 justify-self-end flex justify-end">

--- a/components/states/shared/EquipmentCard.jsx
+++ b/components/states/shared/EquipmentCard.jsx
@@ -1,9 +1,22 @@
 import React from "react";
 import Image from "next/image";
+import { isEmpty } from "lodash";
+
 import CardComponent from "./CardComponent";
 import SelectComponent from "./SelectComponent";
-import { statesText } from "../../../utils/app-text";
 import { MyContext } from "../../ReservationController";
+
+const getTextBasedOnOptions = (choice, options) => {
+  const findOption = options.find(({ value }) => {
+    return choice === value;
+  });
+  // THIS SHOULD NEVER HAPPEN.
+  // If this happens, it means the options do not contain a value that matches the choice
+  if (isEmpty(findOption)) {
+    return null;
+  }
+  return findOption.label;
+};
 
 const EquipmentCard = ({
   choice,
@@ -11,6 +24,7 @@ const EquipmentCard = ({
   icon,
   text,
   options,
+  selectLabel,
   defaultOption = null,
 }) => {
   const [visible, setVisible] = React.useState(false);
@@ -22,11 +36,11 @@ const EquipmentCard = ({
         <CardComponent
           icon={<Image src={icon} alt="" width={150} height={150} />}
           text={
-            choice ? (
+            choice !== null ? (
               <div className="flex flex-col items-center">
                 <span>{text}</span>
                 <span className="italic text-xs font-normal text-gray-800">
-                  {choice}
+                  {getTextBasedOnOptions(choice, options)}
                 </span>
               </div>
             ) : (
@@ -35,7 +49,7 @@ const EquipmentCard = ({
           }
           onClick={() => setVisible(!visible)}
           additionalClassName={
-            choice
+            choice !== null
               ? "bg-green-100 border-green-600 hover:border-green-600"
               : null
           }
@@ -46,7 +60,7 @@ const EquipmentCard = ({
             <SelectComponent
               value={choice}
               setValue={setChoice}
-              label={statesText.equipmentCard.label[context.language]}
+              label={selectLabel}
               options={options}
               defaultValue={defaultOption}
             />

--- a/components/states/shared/SelectComponent.jsx
+++ b/components/states/shared/SelectComponent.jsx
@@ -12,9 +12,9 @@ const SelectComponent = (props) => {
         defaultValue={props.defaultValue}
         value={props.value}
       >
-        {props.options.map((value, idx) => (
-          <MenuItem key={idx} value={value}>
-            {value}
+        {props.options.map(({ label, value }) => (
+          <MenuItem key={value} value={value}>
+            {label}
           </MenuItem>
         ))}
       </Select>

--- a/utils/dictionary.js
+++ b/utils/dictionary.js
@@ -1,0 +1,56 @@
+export const dictionary = {
+  fins: { english: "fins", spanish: "aletas" },
+  choice: { english: "choice", spanish: "opción" },
+  title: {
+    english: "Need equipment?",
+    spanish: "Necesitas equipo?",
+  },
+  wetsuit: {
+    english: "Wetsuit",
+    spanish: "Traje de neopreno",
+  },
+  small: {
+    english: "small",
+    spanish: "pequeño",
+  },
+  medium: {
+    english: "medium",
+    spanish: "mediano",
+  },
+  large: {
+    english: "large",
+    spanish: "grande",
+  },
+  regulator: {
+    english: "regulator",
+    spanish: "regulador",
+  },
+  size: {
+    english: "size",
+    spanish: "talla",
+  },
+  bcd: {
+    english: "bcd",
+    spanish: "bcd",
+  },
+  yes: {
+    english: "yes",
+    spanish: "si",
+  },
+  no: {
+    english: "no",
+    spanish: "no",
+  },
+  mask: {
+    english: "Mask",
+    spanish: "Mascara",
+  },
+  tank: {
+    english: "Tank",
+    spanish: "Tanque",
+  },
+  "100 (large)": {
+    english: "100 (large)",
+    spanish: "100 (grande)",
+  },
+};


### PR DESCRIPTION
Change the equipment state to send integers instead of text for the equipment.


PR that made the change from `text` -> `int` https://github.com/adolfoportilla/diver-list/pull/99